### PR TITLE
Updating js module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Pangea AuthN service is not limited to the following features:
 
 ### Generating the sample app
 
-- Make sure you have NodeJS installed on your system
+- Make sure you have NodeJS (v16.19.0 or later) installed on your system
 
 - Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 

--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,4 +1,4 @@
-export default function Head() {
+const Head = () => {
   return (
     <>
       <title></title>
@@ -8,3 +8,5 @@ export default function Head() {
     </>
   );
 }
+
+export default Head;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,11 +4,7 @@ import AppBar from "../components/AppBar";
 
 import "./globals.css";
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+const RootLayout = ({ children }: { children: React.ReactNode }) => {
   const hostedLoginURL = process?.env?.NEXT_PUBLIC_AUTHN_HOSTED_LOGIN_URL || "";
   const authConfig = {
     clientToken: process?.env?.NEXT_PUBLIC_AUTHN_CLIENT_TOKEN || "",
@@ -21,7 +17,8 @@ export default function RootLayout({
         <head />
         <body style={{ padding: "40px", textAlign: "center" }}>
           <h2>
-            Please configure your environment variables. See the README for more...
+            Please configure your environment variables. See the README for
+            more...
           </h2>
         </body>
       </html>
@@ -40,4 +37,6 @@ export default function RootLayout({
       </body>
     </html>
   );
-}
+};
+
+export default RootLayout;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from "@pangeacyber/react-auth";
 import styles from "./page.module.css";
 
-export default function Home() {
+const Home = () => {
   const { authenticated } = useAuth();
 
   return (
@@ -37,3 +37,5 @@ export default function Home() {
     </main>
   );
 }
+
+export default Home;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,57 +15,20 @@
                 "@types/react": "^18.0.14",
                 "@types/react-dom": "^18.0.5",
                 "typescript": "^4.7.4"
-            }
-        },
-        "../pangea-javascript/packages/react-auth": {
-            "name": "@pangeacyber/react-auth",
-            "version": "0.0.2-beta.11",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/randombytes": "^2.0.0",
-                "axios": "^1.1.3",
-                "lodash": "^4.17.21"
             },
-            "devDependencies": {
-                "@babel/core": "^7.19.6",
-                "@rollup/plugin-babel": "^6.0.2",
-                "@rollup/plugin-commonjs": "^23.0.2",
-                "@rollup/plugin-json": "^5.0.1",
-                "@rollup/plugin-node-resolve": "^15.0.1",
-                "@rollup/plugin-terser": "^0.1.0",
-                "@rollup/plugin-typescript": "^9.0.2",
-                "@types/lodash": "^4.14.186",
-                "@types/node": "^18.11.7",
-                "@types/react": "^18.0.24",
-                "@types/react-dom": "^18.0.8",
-                "@typescript-eslint/eslint-plugin": "^5.51.0",
-                "@typescript-eslint/parser": "^5.51.0",
-                "babel-loader": "^9.0.0",
-                "eslint": "^8.34.0",
-                "react": "17",
-                "react-dom": "17",
-                "rollup": "^3.2.3",
-                "rollup-plugin-dts": "^5.0.0",
-                "rollup-plugin-peer-deps-external": "^2.2.4",
-                "rollup-plugin-polyfill-node": "^0.11.0",
-                "tslib": "^2.4.1",
-                "typescript": "^4.9.5"
-            },
-            "peerDependencies": {
-                "react": "^17.0.2 || ^18.2.0",
-                "react-dom": "^17.0.2 || ^18.2.0"
+            "engines": {
+                "node": ">=16.19.0"
             }
         },
         "node_modules/@next/env": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz",
-            "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ=="
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
+            "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz",
-            "integrity": "sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
+            "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
             "cpu": [
                 "arm64"
             ],
@@ -78,9 +41,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz",
-            "integrity": "sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
+            "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
             "cpu": [
                 "x64"
             ],
@@ -93,9 +56,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz",
-            "integrity": "sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
+            "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
             "cpu": [
                 "arm64"
             ],
@@ -108,9 +71,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz",
-            "integrity": "sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
+            "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
             "cpu": [
                 "arm64"
             ],
@@ -123,9 +86,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz",
-            "integrity": "sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
+            "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
             "cpu": [
                 "x64"
             ],
@@ -138,9 +101,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz",
-            "integrity": "sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
+            "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
             "cpu": [
                 "x64"
             ],
@@ -153,9 +116,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz",
-            "integrity": "sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
+            "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
             "cpu": [
                 "arm64"
             ],
@@ -168,9 +131,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz",
-            "integrity": "sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
+            "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
             "cpu": [
                 "ia32"
             ],
@@ -183,9 +146,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz",
-            "integrity": "sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
+            "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
             "cpu": [
                 "x64"
             ],
@@ -198,9 +161,9 @@
             }
         },
         "node_modules/@pangeacyber/react-auth": {
-            "version": "0.0.3-beta.2",
-            "resolved": "https://registry.npmjs.org/@pangeacyber/react-auth/-/react-auth-0.0.3-beta.2.tgz",
-            "integrity": "sha512-7J1ZDLhrEanmAmXqwVLc9F+hdUztwDjIAjfPyRPkKoZHmJKEmLdnt7iJ1yCMSjqCYaQP/kKjIQh2JbUeH0z/+A==",
+            "version": "0.0.3-beta.3",
+            "resolved": "https://registry.npmjs.org/@pangeacyber/react-auth/-/react-auth-0.0.3-beta.3.tgz",
+            "integrity": "sha512-U7KKZFS8iHvgzC0hkv3reOvfxa1ihIyaENswgn6fi9jsSm9DuJ4FNow3LP+kvZUj/BpXga/r27x7wOs20+hVfg==",
             "dependencies": {
                 "axios": "^1.1.3",
                 "jose": "^4.13.1",
@@ -212,17 +175,17 @@
             }
         },
         "node_modules/@swc/helpers": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-            "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+            "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@types/node": {
-            "version": "18.15.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+            "version": "18.16.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+            "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
             "dev": true
         },
         "node_modules/@types/prop-types": {
@@ -232,9 +195,9 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "18.0.34",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.34.tgz",
-            "integrity": "sha512-NO1UO8941541CJl1BeOXi8a9dNKFK09Gnru5ZJqkm4Q3/WoQJtHvmwt0VX0SB9YCEwe7TfSSxDuaNmx6H2BAIQ==",
+            "version": "18.2.7",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
+            "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
             "dev": true,
             "dependencies": {
                 "@types/prop-types": "*",
@@ -243,9 +206,9 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.0.11",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-            "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+            "version": "18.2.4",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.4.tgz",
+            "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
@@ -263,9 +226,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
-            "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
             "dependencies": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
@@ -284,9 +247,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001477",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001477.tgz",
-            "integrity": "sha512-lZim4iUHhGcy5p+Ri/G7m84hJwncj+Kz7S5aD4hoQfslKZJgt0tHc/hafVbqHC5bbhHb+mrW2JOUHkI5KH7toQ==",
+            "version": "1.0.30001491",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
+            "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -365,9 +328,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.0.tgz",
-            "integrity": "sha512-LSA/XenLPwqk6e2L+PSUNuuY9G4NGsvjRWz6sJcUBmzTLEPJqQh46FHSUxnAQ64AWOkRO6bSXpy3yXuEKZkbIA==",
+            "version": "4.14.4",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+            "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
@@ -430,38 +393,38 @@
             }
         },
         "node_modules/next": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.3.0.tgz",
-            "integrity": "sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
+            "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
             "dependencies": {
-                "@next/env": "13.3.0",
-                "@swc/helpers": "0.4.14",
+                "@next/env": "13.4.4",
+                "@swc/helpers": "0.5.1",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
                 "postcss": "8.4.14",
-                "styled-jsx": "5.1.1"
+                "styled-jsx": "5.1.1",
+                "zod": "3.21.4"
             },
             "bin": {
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": ">=14.6.0"
+                "node": ">=16.8.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "13.3.0",
-                "@next/swc-darwin-x64": "13.3.0",
-                "@next/swc-linux-arm64-gnu": "13.3.0",
-                "@next/swc-linux-arm64-musl": "13.3.0",
-                "@next/swc-linux-x64-gnu": "13.3.0",
-                "@next/swc-linux-x64-musl": "13.3.0",
-                "@next/swc-win32-arm64-msvc": "13.3.0",
-                "@next/swc-win32-ia32-msvc": "13.3.0",
-                "@next/swc-win32-x64-msvc": "13.3.0"
+                "@next/swc-darwin-arm64": "13.4.4",
+                "@next/swc-darwin-x64": "13.4.4",
+                "@next/swc-linux-arm64-gnu": "13.4.4",
+                "@next/swc-linux-arm64-musl": "13.4.4",
+                "@next/swc-linux-x64-gnu": "13.4.4",
+                "@next/swc-linux-x64-musl": "13.4.4",
+                "@next/swc-win32-arm64-msvc": "13.4.4",
+                "@next/swc-win32-ia32-msvc": "13.4.4",
+                "@next/swc-win32-x64-msvc": "13.4.4"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
                 "fibers": ">= 3.1.0",
-                "node-sass": "^6.0.0 || ^7.0.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "sass": "^1.3.0"
@@ -471,9 +434,6 @@
                     "optional": true
                 },
                 "fibers": {
-                    "optional": true
-                },
-                "node-sass": {
                     "optional": true
                 },
                 "sass": {
@@ -584,9 +544,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
         },
         "node_modules/typescript": {
             "version": "4.9.5",
@@ -600,72 +560,80 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/zod": {
+            "version": "3.21.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+            "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
         }
     },
     "dependencies": {
         "@next/env": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz",
-            "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ=="
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
+            "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
         },
         "@next/swc-darwin-arm64": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz",
-            "integrity": "sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
+            "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz",
-            "integrity": "sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
+            "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz",
-            "integrity": "sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
+            "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz",
-            "integrity": "sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
+            "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz",
-            "integrity": "sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
+            "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz",
-            "integrity": "sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
+            "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz",
-            "integrity": "sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
+            "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz",
-            "integrity": "sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
+            "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz",
-            "integrity": "sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
+            "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
             "optional": true
         },
         "@pangeacyber/react-auth": {
-            "version": "0.0.3-beta.2",
-            "resolved": "https://registry.npmjs.org/@pangeacyber/react-auth/-/react-auth-0.0.3-beta.2.tgz",
-            "integrity": "sha512-7J1ZDLhrEanmAmXqwVLc9F+hdUztwDjIAjfPyRPkKoZHmJKEmLdnt7iJ1yCMSjqCYaQP/kKjIQh2JbUeH0z/+A==",
+            "version": "0.0.3-beta.3",
+            "resolved": "https://registry.npmjs.org/@pangeacyber/react-auth/-/react-auth-0.0.3-beta.3.tgz",
+            "integrity": "sha512-U7KKZFS8iHvgzC0hkv3reOvfxa1ihIyaENswgn6fi9jsSm9DuJ4FNow3LP+kvZUj/BpXga/r27x7wOs20+hVfg==",
             "requires": {
                 "axios": "^1.1.3",
                 "jose": "^4.13.1",
@@ -673,17 +641,17 @@
             }
         },
         "@swc/helpers": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-            "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+            "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
             "requires": {
                 "tslib": "^2.4.0"
             }
         },
         "@types/node": {
-            "version": "18.15.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+            "version": "18.16.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+            "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
             "dev": true
         },
         "@types/prop-types": {
@@ -693,9 +661,9 @@
             "dev": true
         },
         "@types/react": {
-            "version": "18.0.34",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.34.tgz",
-            "integrity": "sha512-NO1UO8941541CJl1BeOXi8a9dNKFK09Gnru5ZJqkm4Q3/WoQJtHvmwt0VX0SB9YCEwe7TfSSxDuaNmx6H2BAIQ==",
+            "version": "18.2.7",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
+            "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
             "dev": true,
             "requires": {
                 "@types/prop-types": "*",
@@ -704,9 +672,9 @@
             }
         },
         "@types/react-dom": {
-            "version": "18.0.11",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-            "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+            "version": "18.2.4",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.4.tgz",
+            "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
             "dev": true,
             "requires": {
                 "@types/react": "*"
@@ -724,9 +692,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
-            "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
             "requires": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
@@ -742,9 +710,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001477",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001477.tgz",
-            "integrity": "sha512-lZim4iUHhGcy5p+Ri/G7m84hJwncj+Kz7S5aD4hoQfslKZJgt0tHc/hafVbqHC5bbhHb+mrW2JOUHkI5KH7toQ=="
+            "version": "1.0.30001491",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
+            "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA=="
         },
         "client-only": {
             "version": "0.0.1",
@@ -786,9 +754,9 @@
             }
         },
         "jose": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.0.tgz",
-            "integrity": "sha512-LSA/XenLPwqk6e2L+PSUNuuY9G4NGsvjRWz6sJcUBmzTLEPJqQh46FHSUxnAQ64AWOkRO6bSXpy3yXuEKZkbIA=="
+            "version": "4.14.4",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+            "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g=="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -827,25 +795,26 @@
             "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
         },
         "next": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.3.0.tgz",
-            "integrity": "sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==",
+            "version": "13.4.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
+            "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
             "requires": {
-                "@next/env": "13.3.0",
-                "@next/swc-darwin-arm64": "13.3.0",
-                "@next/swc-darwin-x64": "13.3.0",
-                "@next/swc-linux-arm64-gnu": "13.3.0",
-                "@next/swc-linux-arm64-musl": "13.3.0",
-                "@next/swc-linux-x64-gnu": "13.3.0",
-                "@next/swc-linux-x64-musl": "13.3.0",
-                "@next/swc-win32-arm64-msvc": "13.3.0",
-                "@next/swc-win32-ia32-msvc": "13.3.0",
-                "@next/swc-win32-x64-msvc": "13.3.0",
-                "@swc/helpers": "0.4.14",
+                "@next/env": "13.4.4",
+                "@next/swc-darwin-arm64": "13.4.4",
+                "@next/swc-darwin-x64": "13.4.4",
+                "@next/swc-linux-arm64-gnu": "13.4.4",
+                "@next/swc-linux-arm64-musl": "13.4.4",
+                "@next/swc-linux-x64-gnu": "13.4.4",
+                "@next/swc-linux-x64-musl": "13.4.4",
+                "@next/swc-win32-arm64-msvc": "13.4.4",
+                "@next/swc-win32-ia32-msvc": "13.4.4",
+                "@next/swc-win32-x64-msvc": "13.4.4",
+                "@swc/helpers": "0.5.1",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
                 "postcss": "8.4.14",
-                "styled-jsx": "5.1.1"
+                "styled-jsx": "5.1.1",
+                "zod": "3.21.4"
             }
         },
         "picocolors": {
@@ -912,15 +881,20 @@
             }
         },
         "tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
         },
         "typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
+        },
+        "zod": {
+            "version": "3.21.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+            "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
         "@types/react": "^18.0.14",
         "@types/react-dom": "^18.0.5",
         "typescript": "^4.7.4"
+    },
+    "engines": {
+        "node": ">=16.19.0"
     }
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -34,7 +34,10 @@ const validateToken = async (token: string) => {
 
       return responseJSON.status === "Success";
     } catch (error) {
-      console.error("Error:", error);
+      console.error(
+        "Error occured during token validation. Looks like environment variables haven't been set correctly, or the service token has expired",
+        error
+      );
     }
   }
   return result;
@@ -42,6 +45,17 @@ const validateToken = async (token: string) => {
 
 export const withAPIAuthentication = (apiHandler: NextApiHandler) => {
   return async (req: NextApiRequest, res: NextApiResponse) => {
+    // Check the environment variables
+    if (
+      !process.env.NEXT_PUBLIC_PANGEA_DOMAIN ||
+      process.env.AUTHN_SERVICE_TOKEN
+    ) {
+      console.error(
+        "Missing environment variables, please make sure you have NEXT_PUBLIC_PANGEA_DOMAIN and AUTHN_SERVICE_TOKEN set in your .env file"
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
     const isTokenValid = await validateToken(getBearerToken(req));
 
     // Authentication failed, return 401


### PR DESCRIPTION
Due to a bug in the latest NextJS, all "use client" components should be exported with the format of `export default COMPONENTNAME`